### PR TITLE
fix: change website title to RDS Website Calendar

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,7 +1,9 @@
-import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from 'remix';
+import {
+  Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration,
+} from 'remix';
 import type { MetaFunction } from 'remix';
 import styles from './tailwind.css';
-import globalStylesUrl from '~/styles/global.css';
+import globalStylesUrl from './styles/global.css';
 
 export function links() {
   return [
@@ -10,9 +12,7 @@ export function links() {
   ];
 }
 
-export const meta: MetaFunction = () => {
-  return { title: 'New Remix App' };
-};
+export const meta: MetaFunction = () => ({ title: 'RDS Website Calendar' });
 
 export default function App() {
   return (


### PR DESCRIPTION
This PR closes issue#15

Changed the site title from "New Remix App" to "RDS Website Calendar"

### Screenshot of site title before changes
![previous](https://user-images.githubusercontent.com/28630412/172124584-d7f08f26-87a9-4eaf-b25e-0f0b0af2ec98.JPG)


### Screenshot of site title after change
![after change](https://user-images.githubusercontent.com/28630412/172124647-28faf7b4-291e-4376-9afa-39475afaf554.JPG)
