### PR TITLE
style : add useWindowSize hook & center confetti

### DIFF
--- a/app/hooks/useWindowSize.tsx
+++ b/app/hooks/useWindowSize.tsx
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export type WindowSize = {
+  width: number | undefined;
+  height: number | undefined;
+};
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    const updateWindowSize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+    window.addEventListener('resize', updateWindowSize);
+    updateWindowSize();
+    return () => window.removeEventListener('resize', updateWindowSize);
+  }, []);
+  return windowSize;
+};
+
+export { useWindowSize };

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,7 +1,9 @@
 import Confetti from 'react-confetti';
+import { useWindowSize } from '~/hooks/useWindowSize';
+
 export default function Index() {
-  const width = 1000;
-  const height = 1000;
+  const { width, height } = useWindowSize();
+
   return (
     <div className="container">
       <h4 className="border border-blue m-auto text-center text-3xl text-blue-700">RDS Calendar</h4>


### PR DESCRIPTION
 ## This PR closes issue#2

## Files included:

- [ ] app/hooks/useWindowSize.tsx - hook to return size of current viewport.
- [ ] app/routes/index.tsx

## Visual changes
Before the changes
![previousConfetti](https://user-images.githubusercontent.com/28630412/173627929-920d11c8-8027-4880-a0b0-e8923beff456.png)

After the changes
![updatedConfetti](https://user-images.githubusercontent.com/28630412/173627982-18fd2d08-ceb4-4991-9083-324e1a25c554.gif)

