### PR TITLE
fix: avoid network call for new event, create new util func for parsing single event, pass navState to new event

### DIFF
--- a/app/routes/event/$eventId.tsx
+++ b/app/routes/event/$eventId.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { useParams, useLoaderData, ShouldRevalidateFunction } from '@remix-run/react';
+import { useParams, useLoaderData, ShouldRevalidateFunction, useLocation } from '@remix-run/react';
 import { LoaderFunction, json } from '@remix-run/node';
 import EventModal from '~/components/common/eventModal';
 import { useStore } from '~/store/useStore';
 import { CalEvent, CalendarEventProps } from '~/utils/interfaces';
 import { dummyEvent } from '~/constants/events.constants';
 import { getEventById } from '~/constants/urls.constants';
-import { parseEvents } from '~/utils/event.utils';
+import { parseEvent } from '~/utils/event.utils';
 
 type LoaderData = {
   event: any;
@@ -18,9 +18,13 @@ export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url);
   const cookie = request.headers.get('cookie');
 
+  const eventId = url.pathname.split('/')[2];
+
+  if (eventId === 'new') return { event: dummyEvent };
+
   try {
     const response = await axios.get(
-      getEventById(process.env.API_HOST as string, parseInt(url.pathname.split('/')[2], 10)),
+      getEventById(process.env.API_HOST as string, parseInt(eventId, 10)),
       {
         headers: {
           'Content-Type': 'application/json',
@@ -30,13 +34,10 @@ export const loader: LoaderFunction = async ({ request }) => {
     );
     return json<LoaderData>({ event: response.data.data, error: null });
   } catch (error) {
-    if ((url.pathname.split('/')[2] as string) !== 'new') {
-      throw new Response(null, {
-        status: 404,
-        statusText: 'Not Found',
-      });
-    }
-    return { event: dummyEvent };
+    throw new Response(null, {
+      status: 404,
+      statusText: 'Not Found',
+    });
   }
 };
 
@@ -44,10 +45,10 @@ const shouldRevalidate: ShouldRevalidateFunction = ({}) => false;
 
 const EventDetails = () => {
   const { event } = useLoaderData();
-
+  const { state: navState } = useLocation();
   const { events: eventsList } = useStore((state) => state);
   const [calendarEvent, setCalendarEvent] = useState<CalendarEventProps>({
-    event: parseEvents([event])[0] ?? dummyEvent,
+    event: parseEvent(event) ?? dummyEvent,
   });
 
   const params = useParams();
@@ -63,6 +64,10 @@ const EventDetails = () => {
           event: { ...calEvent },
         });
       }
+    } else {
+      setCalendarEvent({
+        event: { ...event, start: navState.start, end: navState.end },
+      });
     }
   }, [event.id]);
 

--- a/app/utils/event.utils.ts
+++ b/app/utils/event.utils.ts
@@ -2,6 +2,18 @@ import dayjs from 'dayjs';
 import { defaultCalendarId } from '../constants/urls.constants';
 import { CalEvent } from '~/utils/interfaces';
 
+// parse event obj from backend to frontend format
+export const parseEvent = (event: any): CalEvent => {
+  const { name, startTime, endTime, Attendees, isDeleted, ...remainingEventDetails } = event;
+  return {
+    ...remainingEventDetails,
+    title: name,
+    start: dayjs(startTime).toDate(),
+    end: dayjs(endTime).toDate(),
+    attendees: Attendees,
+  };
+};
+
 // parse event objs from backend to frontend format
 export const parseEvents = (events: any[]): Array<CalEvent> =>
   events?.reduce((acc, event) => {


### PR DESCRIPTION
### What is the change?
- avoid server-side network call for new event
-- We were doing a network call even on a new modal route which was not necessary. I applied a check on `url.pathname` and avoid the network call in case of a new event.

- create new util function for parsing single event
-- We were putting a single event in an array and then running reduce on that array just to parse one single event. This is unnecessary and a complex operation. I created a new function to format a single event.

- pass navState to new event
-- We were passing `new Date()` to the eventModal in case of new event, where it should be using the date-time range which the user selected on the calendar. I consumed the state which we had passed in navigate() and updated the event object.

Provide a small description of what did you change and provide the reference to the issue ticket.

### Is it bug?

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [ ] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.
