### PR TITLE
fix: handle null navstate

### DIFF
--- a/app/routes/event/$eventId.tsx
+++ b/app/routes/event/$eventId.tsx
@@ -65,8 +65,11 @@ const EventDetails = () => {
         });
       }
     } else {
+      const start = navState && navState.start ? navState.start : dummyEvent.start;
+      const end = navState && navState.end ? navState.end : dummyEvent.end;
+
       setCalendarEvent({
-        event: { ...event, start: navState.start, end: navState.end },
+        event: { ...event, start, end },
       });
     }
   }, [event.id]);


### PR DESCRIPTION
### What is the change?

Fixed `/events/new` route, that was crashing when opened directly as the state from useLocation is null.

Provide a small description of what did you change and provide the reference to the issue ticket.

### Is it bug?

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [ ] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.
