### PR TITLE
fix: mock useLocation

### DIFF
--- a/app/components/common/rdsCalendar/index.test.tsx
+++ b/app/components/common/rdsCalendar/index.test.tsx
@@ -8,11 +8,13 @@ import RdsCalendar from '.';
 import { CalendarEventProps, CalEvent, UpdateEvent } from '~/utils/interfaces';
 
 // pay attention to write it at the top level of your file
-const mockedUsedNavigate = jest.fn();
+const mockedUseNavigate = jest.fn();
+const mockedUseLocation = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-   ...jest.requireActual('react-router-dom') as any,
-  useNavigate: () => mockedUsedNavigate,
+  ...(jest.requireActual('react-router-dom') as any),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: () => mockedUseLocation,
 }));
 
 interface RdsCalendarProps {
@@ -53,6 +55,11 @@ const defaultProps: RdsCalendarProps = {
 };
 
 describe('RdsCalendar', () => {
+  beforeEach(() => {
+    mockedUseNavigate.mockReturnValue(jest.fn());
+    mockedUseLocation.mockReturnValue({ pathname: '/some-path' });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
### What is the change?

Provide a small description of what did you change and provide the reference to the issue ticket.

tests were failing with error: useLocation() may be used only in the context of a <Router> component

fixed it by mocking useLocation in tests.

### Is it bug?
yes

- Steps to repro
- Expected
- Actual

### \*Dev Tested?

- [ ] Yes
- [ ] No

### \*Tested on:

#### Platforms

- [ ] Web

#### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox

### Before / After Change Screenshots

> For visual or interaction changes. Can be video / screenshot.

closes #214 